### PR TITLE
Update the outdated hotkey `Ctrl + R` / `Cmd + R`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This plugin extends the MathJax support in Obsidian with a MathJax preamble file which is loaded at startup. It also enables some additional MathJax extensions (notably `mhchem` and `bussproofs`). 
 
-The preamble is stored in a `preamble.sty` file in the root of the vault. To reload changes to the preamble refresh the vault using `Cmd + R` / `Ctrl + R`. 
+The preamble is stored in a `preamble.sty` file in the root of the vault. To reload changes to the preamble run the command "Reload app without saving."
 
 ### Installation 
 


### PR DESCRIPTION
Hi, thank you for making this great plugin. As far as I know, Obsidian is the only markdown note-taking app that allows the use of a preamble (at least among all the well-known ones), thanks to this plugin.

---

Currently, no command is assigned to `Cmd` + `R` on Mac by default. 
I assume this was intended to indicate the command "Reload app without saving" so I updated the README accordingly.
Please correct me if I'm wrong.

<img width="1552" alt="image" src="https://github.com/wei2912/obsidian-latex/assets/72342591/af053cf2-e70b-4bdb-9e90-7d2319a5a860">
